### PR TITLE
Post 테이블에 commentCount 컬럼을 추가합니다.

### DIFF
--- a/application/src/integrationTest/kotlin/com/jinuk/toy/applicaiton/comment/command/usecase/CreateCommentUsecaseTest.kt
+++ b/application/src/integrationTest/kotlin/com/jinuk/toy/applicaiton/comment/command/usecase/CreateCommentUsecaseTest.kt
@@ -2,6 +2,8 @@ package com.jinuk.toy.applicaiton.comment.command.usecase
 
 import com.jinuk.toy.applicaiton.IntegrationTest
 import com.jinuk.toy.domain.comment.jpa.CommentRepository
+import com.jinuk.toy.domain.post.PostFixture
+import com.jinuk.toy.domain.post.jpa.PostRepository
 import com.jinuk.toy.util.faker.faker
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
@@ -9,22 +11,33 @@ import io.kotest.matchers.shouldBe
 internal class CreateCommentUsecaseTest(
     private val createCommentUsecase: CreateCommentUsecase,
     private val commentRepository: CommentRepository,
+    private val postFixture: PostFixture,
+    private val postRepository: PostRepository,
 ) : IntegrationTest, DescribeSpec(
-        {
-            describe("댓글 생성 유스케이스") {
-                it("생성 성공") {
-                    val userId = faker.random().nextLong()
-                    val postId = faker.random().nextLong()
-                    val command = CreateCommentCommand(userId, postId, null, "content")
-                    createCommentUsecase(command)
+    {
+        describe("댓글 생성 유스케이스") {
+            it("생성 성공") {
+                val post = postFixture.persist()
+                val userId = faker.random().nextLong()
+                val command = CreateCommentCommand(userId, post.id, null, "content")
+                createCommentUsecase(command)
 
-                    val searched = commentRepository.findByUserIdAndPostId(userId, postId)
-                    searched.size shouldBe 1
-                    searched[0].userId shouldBe command.userId
-                    searched[0].postId shouldBe command.postId
-                    searched[0].parentCommentId shouldBe command.parentCommentId
-                    searched[0].content shouldBe command.content
-                }
+                val comments = commentRepository.findByUserIdAndPostId(userId, post.id)
+                comments.size shouldBe 1
+                comments[0].userId shouldBe command.userId
+                comments[0].postId shouldBe command.postId
+                comments[0].parentCommentId shouldBe command.parentCommentId
+                comments[0].content shouldBe command.content
+
+                post.commentCount + 1 shouldBe postRepository.findById(post.id)?.commentCount
+
+                createCommentUsecase(command)
+                createCommentUsecase(command)
+                createCommentUsecase(command)
+                createCommentUsecase(command)
+
+                post.commentCount + 5 shouldBe postRepository.findById(post.id)?.commentCount
             }
-        },
-    )
+        }
+    },
+)

--- a/application/src/integrationTest/kotlin/com/jinuk/toy/applicaiton/comment/command/usecase/DeleteCommentUsecaseTest.kt
+++ b/application/src/integrationTest/kotlin/com/jinuk/toy/applicaiton/comment/command/usecase/DeleteCommentUsecaseTest.kt
@@ -3,6 +3,8 @@ package com.jinuk.toy.applicaiton.comment.command.usecase
 import com.jinuk.toy.applicaiton.IntegrationTest
 import com.jinuk.toy.domain.comment.CommentFixture
 import com.jinuk.toy.domain.comment.jpa.CommentRepository
+import com.jinuk.toy.domain.post.PostFixture
+import com.jinuk.toy.domain.post.jpa.PostRepository
 import com.jinuk.toy.util.faker.faker
 import com.jinuk.toy.util.faker.randomLong
 import io.kotest.assertions.throwables.shouldThrow
@@ -13,20 +15,26 @@ internal class DeleteCommentUsecaseTest(
     private val deleteCommentUsecase: DeleteCommentUsecase,
     private val commentRepository: CommentRepository,
     private val commentFixture: CommentFixture,
+    private val postFixture: PostFixture,
+    private val postRepository: PostRepository,
 ) : IntegrationTest, DescribeSpec(
         {
             describe("댓글 삭제 유스케이스") {
                 it("삭제 성공") {
-                    val exits = commentFixture.persist()
+                    val post = postFixture.persist()
+                    val exits = commentFixture.persist(postId = post.id)
                     val command = DeleteCommentCommand(exits.userId, exits.postId, exits.id)
 
                     deleteCommentUsecase(command)
                     val comment = commentRepository.findById(exits.id)
                     comment shouldBe null
+
+                    post.commentCount - 1 shouldBe postRepository.findById(post.id)?.commentCount
                 }
 
                 it("삭제 실패 - 작성자가 아닌 유저") {
-                    val exits = commentFixture.persist()
+                    val post = postFixture.persist()
+                    val exits = commentFixture.persist(postId = post.id)
                     val command = DeleteCommentCommand(faker.randomLong(), exits.postId, exits.id)
 
                     shouldThrow<IllegalArgumentException> {
@@ -35,7 +43,8 @@ internal class DeleteCommentUsecaseTest(
                 }
 
                 it("삭제 실패 - 게시글에 속하지 않은 댓글") {
-                    val exits = commentFixture.persist()
+                    val post = postFixture.persist()
+                    val exits = commentFixture.persist(postId = post.id)
                     val command = DeleteCommentCommand(exits.userId, faker.randomLong(), exits.id)
 
                     shouldThrow<IllegalArgumentException> {

--- a/application/src/integrationTest/kotlin/com/jinuk/toy/applicaiton/post/query/usecase/GetPostDetailUsecaseTest.kt
+++ b/application/src/integrationTest/kotlin/com/jinuk/toy/applicaiton/post/query/usecase/GetPostDetailUsecaseTest.kt
@@ -1,14 +1,11 @@
 package com.jinuk.toy.applicaiton.post.query.usecase
 
 import com.jinuk.toy.applicaiton.IntegrationTest
-import com.jinuk.toy.domain.comment.CommentFixture
 import com.jinuk.toy.domain.like.LikeFixture
 import com.jinuk.toy.domain.like.LikeTarget
 import com.jinuk.toy.domain.like.LikeType
 import com.jinuk.toy.domain.post.PostFixture
 import com.jinuk.toy.domain.post.UserFixture
-import com.jinuk.toy.domain.post.service.cacheKeyByGetById
-import com.jinuk.toy.infra.redis.cache.cacheEvict
 import com.jinuk.toy.util.faker.faker
 import com.jinuk.toy.util.faker.randomLong
 import io.kotest.assertions.throwables.shouldThrow
@@ -20,7 +17,6 @@ class GetPostDetailUsecaseTest(
     private val postFixture: PostFixture,
     private val userFixture: UserFixture,
     private val likeFixture: LikeFixture,
-    private val commentFixture: CommentFixture,
 ) : IntegrationTest, DescribeSpec(
         {
             describe("게시글 상세 조회 유스케이스") {
@@ -28,17 +24,13 @@ class GetPostDetailUsecaseTest(
                     val postWriter = userFixture.persist()
                     val viewer = userFixture.persist()
 
-                    val post = postFixture.persist(userId = postWriter.id)
-                    cacheEvict(cacheKeyByGetById(post.id))
+                    val post = postFixture.persist(userId = postWriter.id, commentCount = 0)
 
                     val likeTarget = LikeTarget(LikeType.POST, post.id.toString())
                     likeFixture.persist(targetType = likeTarget.type, targetId = likeTarget.id, userId = viewer.id)
                     likeFixture.persist(targetType = likeTarget.type, targetId = likeTarget.id)
                     likeFixture.persist(targetType = likeTarget.type, targetId = likeTarget.id)
                     likeFixture.persist(targetType = likeTarget.type, targetId = likeTarget.id)
-
-                    commentFixture.persist(postId = post.id)
-                    commentFixture.persist(postId = post.id)
 
                     it("조회 성공") {
                         val result = getPostDetailUsecase(GetPostDetailQuery(post.id, viewer.id))
@@ -49,7 +41,6 @@ class GetPostDetailUsecaseTest(
                         result.title shouldBe post.title
                         result.content shouldBe post.content
                         result.likeCount shouldBe 4
-                        result.commentCount shouldBe 2
                         result.isViewerLike shouldBe true
                     }
 

--- a/application/src/integrationTest/kotlin/com/jinuk/toy/applicaiton/post/query/usecase/SearchPostUsecaseTest.kt
+++ b/application/src/integrationTest/kotlin/com/jinuk/toy/applicaiton/post/query/usecase/SearchPostUsecaseTest.kt
@@ -1,7 +1,6 @@
 package com.jinuk.toy.applicaiton.post.query.usecase
 
 import com.jinuk.toy.applicaiton.IntegrationTest
-import com.jinuk.toy.domain.comment.CommentFixture
 import com.jinuk.toy.domain.post.PostFixture
 import com.jinuk.toy.domain.post.UserFixture
 import com.jinuk.toy.domain.post.value.PostTitle
@@ -11,7 +10,6 @@ import io.kotest.matchers.shouldBe
 class SearchPostUsecaseTest(
     private val searchPostUsecase: SearchPostUsecase,
     private val postFixture: PostFixture,
-    private val commentFixture: CommentFixture,
     private val userFixture: UserFixture,
 ) : IntegrationTest, DescribeSpec(
         {
@@ -20,14 +18,9 @@ class SearchPostUsecaseTest(
                     val user = userFixture.persist()
                     val posts =
                         (1..20).map {
-                            postFixture.persist(title = PostTitle("title$it"), userId = user.id)
+                            postFixture.persist(title = PostTitle("title$it"), userId = user.id, commentCount = 0)
                         }
                     val postsSize = posts.size
-
-                    val commentCount = 5
-                    repeat(commentCount) {
-                        commentFixture.persist(postId = posts[postsSize - 3].id)
-                    }
 
                     val query = SearchPostQuery(keyword = "title", page = 1, size = 3)
                     val result = searchPostUsecase(query)
@@ -41,7 +34,6 @@ class SearchPostUsecaseTest(
                     content[1].id shouldBe posts[postsSize - 2].id
                     content[2].id shouldBe posts[postsSize - 3].id
                     content[2].userName shouldBe user.username
-                    content[2].commentCount shouldBe commentCount
                 }
             }
         },

--- a/application/src/main/kotlin/com/jinuk/toy/applicaiton/comment/command/usecase/CreateCommentUsecase.kt
+++ b/application/src/main/kotlin/com/jinuk/toy/applicaiton/comment/command/usecase/CreateCommentUsecase.kt
@@ -2,14 +2,17 @@ package com.jinuk.toy.applicaiton.comment.command.usecase
 
 import com.jinuk.toy.domain.comment.Comment
 import com.jinuk.toy.domain.comment.service.CommentCommandService
+import com.jinuk.toy.domain.post.service.PostCommandService
 import org.springframework.stereotype.Service
 
 @Service
 class CreateCommentUsecase(
     private val commentCommandService: CommentCommandService,
+    private val postCommandService: PostCommandService,
 ) {
     operator fun invoke(command: CreateCommentCommand) {
         commentCommandService.save(command.toComment())
+        postCommandService.increaseCommentCount(command.postId)
     }
 }
 

--- a/application/src/main/kotlin/com/jinuk/toy/applicaiton/comment/command/usecase/DeleteCommentUseCase.kt
+++ b/application/src/main/kotlin/com/jinuk/toy/applicaiton/comment/command/usecase/DeleteCommentUseCase.kt
@@ -1,13 +1,18 @@
 package com.jinuk.toy.applicaiton.comment.command.usecase
 
 import com.jinuk.toy.domain.comment.service.CommentCommandService
+import com.jinuk.toy.domain.post.service.PostCommandService
 import org.springframework.stereotype.Service
 
 @Service
 class DeleteCommentUsecase(
     private val commentCommandService: CommentCommandService,
+    private val postCommandService: PostCommandService,
 ) {
-    operator fun invoke(command: DeleteCommentCommand) = commentCommandService.delete(command.commentId, command.userId, command.postId)
+    operator fun invoke(command: DeleteCommentCommand) {
+        commentCommandService.delete(command.commentId, command.userId, command.postId)
+        postCommandService.decreaseCommentCount(command.postId)
+    }
 }
 
 data class DeleteCommentCommand(

--- a/application/src/main/kotlin/com/jinuk/toy/applicaiton/post/command/usecase/UpdatePostUsecase.kt
+++ b/application/src/main/kotlin/com/jinuk/toy/applicaiton/post/command/usecase/UpdatePostUsecase.kt
@@ -3,9 +3,7 @@ package com.jinuk.toy.applicaiton.post.command.usecase
 import com.jinuk.toy.domain.post.Post
 import com.jinuk.toy.domain.post.service.PostCommandService
 import com.jinuk.toy.domain.post.service.PostQueryService
-import com.jinuk.toy.domain.post.service.cacheKeyByGetById
 import com.jinuk.toy.domain.post.value.PostTitle
-import com.jinuk.toy.infra.redis.cache.cacheEvict
 import org.springframework.stereotype.Service
 
 @Service
@@ -17,9 +15,7 @@ class UpdatePostUsecase(
         require(!postQueryService.existsByTitle(command.title.value)) { "이미 존재하는 게시글 제목입니다." }
         val post = postQueryService.getById(command.id)
         val updatedPost = post.update(command)
-        return postCommandService.save(updatedPost).also {
-            cacheEvict(cacheKeyByGetById(post.id))
-        }
+        return postCommandService.save(updatedPost)
     }
 }
 

--- a/application/src/main/kotlin/com/jinuk/toy/applicaiton/post/query/result/PostDetailResult.kt
+++ b/application/src/main/kotlin/com/jinuk/toy/applicaiton/post/query/result/PostDetailResult.kt
@@ -14,7 +14,7 @@ data class PostDetailResult(
     val content: String,
     val isViewerLike: Boolean,
     val likeCount: Int,
-    val commentCount: Int,
+    val commentCount: Long,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime,
 ) {
@@ -24,7 +24,7 @@ data class PostDetailResult(
             writer: User,
             isViewerLike: Boolean,
             likeCount: Int,
-            commentCount: Int,
+            commentCount: Long,
         ): PostDetailResult {
             return with(post) {
                 PostDetailResult(

--- a/application/src/main/kotlin/com/jinuk/toy/applicaiton/post/query/usecase/GetPostDetailUsecase.kt
+++ b/application/src/main/kotlin/com/jinuk/toy/applicaiton/post/query/usecase/GetPostDetailUsecase.kt
@@ -28,14 +28,13 @@ class GetPostDetailUsecase(
             } ?: false
 
         val likeCount = likeQueryService.countByTarget(likeTarget)
-        val commentCount = commentQueryService.countByPostId(post.id)
 
         return PostDetailResult.from(
             post = post,
             writer = writer,
             isViewerLike = isViewerLike,
             likeCount = likeCount,
-            commentCount = commentCount,
+            commentCount = post.commentCount,
         )
     }
 }

--- a/application/src/main/kotlin/com/jinuk/toy/applicaiton/post/query/usecase/SearchPostUsecase.kt
+++ b/application/src/main/kotlin/com/jinuk/toy/applicaiton/post/query/usecase/SearchPostUsecase.kt
@@ -1,6 +1,5 @@
 package com.jinuk.toy.applicaiton.post.query.usecase
 
-import com.jinuk.toy.domain.comment.service.CommentQueryService
 import com.jinuk.toy.domain.post.Post
 import com.jinuk.toy.domain.post.service.PostQueryService
 import com.jinuk.toy.domain.post.value.PostTitle
@@ -16,7 +15,6 @@ import java.time.LocalDateTime
 @Service
 class SearchPostUsecase(
     private val postQueryService: PostQueryService,
-    private val commentQueryService: CommentQueryService,
     private val userQueryService: UserQueryService,
 ) {
     operator fun invoke(query: SearchPostQuery): Page<SearchedPostResult> {
@@ -34,11 +32,8 @@ class SearchPostUsecase(
         pageable: Pageable,
         totalSize: Long,
     ): Page<SearchedPostResult> {
-        val postIds = posts.map { it.id }
         val userIds = posts.map { it.userId }
-
         val userMap = userQueryService.findByIdIn(userIds).associateBy { it.id }
-        val commentGroup = commentQueryService.findByPostIdIn(postIds).groupBy { it.postId }
 
         val content =
             posts.map {
@@ -46,7 +41,7 @@ class SearchPostUsecase(
                     id = it.id,
                     title = it.title,
                     userName = userMap.getValue(it.userId).username,
-                    commentCount = commentGroup[it.id]?.size ?: 0,
+                    commentCount = it.commentCount,
                     createdAt = it.createdAt,
                     updatedAt = it.updatedAt,
                 )
@@ -68,7 +63,7 @@ data class SearchedPostResult(
     val id: Long,
     val title: PostTitle,
     val userName: Username,
-    val commentCount: Int,
+    val commentCount: Long,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime,
 )

--- a/domain/comment/src/main/kotlin/com/jinuk/toy/domain/comment/service/CommentQueryService.kt
+++ b/domain/comment/src/main/kotlin/com/jinuk/toy/domain/comment/service/CommentQueryService.kt
@@ -12,11 +12,8 @@ class CommentQueryService(
 
     fun getById(id: Long) = findById(id) ?: throw NoSuchElementException("존재하지 않는 댓글입니다.")
 
-    fun countByPostId(id: Long) = commentRepository.countByPostId(id)
-
-    fun findByPostId(id: Long) = commentRepository.findByPostId(id)
-
-    fun findByPostIdAndParentCommentIdIsNotNull(postId: Long) = commentRepository.findByPostIdAndParentCommentIdIsNotNull(postId)
+    fun findByPostIdAndParentCommentIdIsNotNull(postId: Long) =
+        commentRepository.findByPostIdAndParentCommentIdIsNotNull(postId)
 
     fun findByPostIdAndParentCommentIdIsNullOrderByIdDesc(
         postId: Long,
@@ -25,6 +22,4 @@ class CommentQueryService(
         postId,
         pageable,
     )
-
-    fun findByPostIdIn(id: List<Long>) = commentRepository.findByPostIdIn(id)
 }

--- a/domain/post/src/main/kotlin/com/jinuk/toy/domain/post/Post.kt
+++ b/domain/post/src/main/kotlin/com/jinuk/toy/domain/post/Post.kt
@@ -12,6 +12,7 @@ data class Post(
     val userId: Long,
     val title: PostTitle,
     val content: String,
+    val commentCount: Long = 0L,
 ) : BaseDomain(_id, createdAt, updatedAt)
 
 internal fun PostEntity.toModel() =
@@ -20,6 +21,7 @@ internal fun PostEntity.toModel() =
         userId = userId,
         title = PostTitle(title),
         content = content,
+        commentCount = commentCount,
         createdAt = createdAt,
         updatedAt = updatedAt,
     )
@@ -30,6 +32,7 @@ internal fun Post.toEntity() =
         userId = userId,
         title = title.value,
         content = content,
+        commentCount = commentCount,
         createdAt = createdAt,
         updatedAt = updatedAt,
     )

--- a/domain/post/src/main/kotlin/com/jinuk/toy/domain/post/Post.kt
+++ b/domain/post/src/main/kotlin/com/jinuk/toy/domain/post/Post.kt
@@ -13,7 +13,11 @@ data class Post(
     val title: PostTitle,
     val content: String,
     val commentCount: Long = 0L,
-) : BaseDomain(_id, createdAt, updatedAt)
+) : BaseDomain(_id, createdAt, updatedAt) {
+    fun increaseCommentCount() = this.copy(commentCount = commentCount + 1)
+
+    fun decreaseCommentCount() = this.copy(commentCount = commentCount - 1)
+}
 
 internal fun PostEntity.toModel() =
     Post(

--- a/domain/post/src/main/kotlin/com/jinuk/toy/domain/post/service/PostQueryService.kt
+++ b/domain/post/src/main/kotlin/com/jinuk/toy/domain/post/service/PostQueryService.kt
@@ -1,29 +1,16 @@
 package com.jinuk.toy.domain.post.service
 
-import com.fasterxml.jackson.core.type.TypeReference
-import com.jinuk.toy.domain.post.Post
 import com.jinuk.toy.domain.post.jpa.PostRepository
-import com.jinuk.toy.infra.redis.cache.cached
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
-import java.time.Duration
 
 @Service
 class PostQueryService(
     private val postRepository: PostRepository,
 ) {
-    fun getById(id: Long) =
-        cached(
-            key = cacheKeyByGetById(id),
-            expire = Duration.ofMinutes(10),
-            returnType = object : TypeReference<Post>() {},
-        ) {
-            postRepository.findById(id) ?: throw NoSuchElementException("존재하지 않는 게시글입니다.")
-        }
+    fun getById(id: Long) = postRepository.findById(id) ?: throw NoSuchElementException("존재하지 않는 게시글입니다.")
 
     fun existsByTitle(title: String) = postRepository.existsByTitle(title)
-
-    fun existsById(postId: Long) = postRepository.existsById(postId)
 
     fun findByTitleStartsWithIgnoreCaseOrderByIdDesc(
         title: String,
@@ -35,5 +22,3 @@ class PostQueryService(
 
     fun findByOrderByIdDesc(pageable: Pageable) = postRepository.findByOrderByIdDesc(pageable)
 }
-
-fun cacheKeyByGetById(id: Long) = "PostQueryService.getById.id:$id"

--- a/domain/post/src/testFixtures/kotlin/com/jinuk/toy/domain/post/PostFixture.kt
+++ b/domain/post/src/testFixtures/kotlin/com/jinuk/toy/domain/post/PostFixture.kt
@@ -35,6 +35,7 @@ class PostFixture(
             userId = userId,
             title = title,
             content = content,
+            commentCount = commentCount,
         ),
     )
 }

--- a/domain/post/src/testFixtures/kotlin/com/jinuk/toy/domain/post/PostFixture.kt
+++ b/domain/post/src/testFixtures/kotlin/com/jinuk/toy/domain/post/PostFixture.kt
@@ -16,10 +16,12 @@ class PostFixture(
             userId: Long = faker.randomLong(),
             title: PostTitle = PostTitle(faker.randomString(20)),
             content: String = faker.randomString(100),
+            commentCount: Long = faker.randomLong(),
         ) = Post(
             userId = userId,
             title = title,
             content = content,
+            commentCount = commentCount,
         )
     }
 
@@ -27,5 +29,12 @@ class PostFixture(
         userId: Long = faker.randomLong(),
         title: PostTitle = PostTitle(faker.randomString(20)),
         content: String = faker.randomString(100),
-    ) = postRepository.save(create(userId, title, content))
+        commentCount: Long = faker.randomLong(),
+    ) = postRepository.save(
+        create(
+            userId = userId,
+            title = title,
+            content = content,
+        ),
+    )
 }

--- a/infra/rdb/src/main/kotlin/com/jinuk/toy/infra/rdb/post/entity/PostEntity.kt
+++ b/infra/rdb/src/main/kotlin/com/jinuk/toy/infra/rdb/post/entity/PostEntity.kt
@@ -23,6 +23,8 @@ class PostEntity(
     val title: String,
     @Column(name = "content")
     val content: String,
+    @Column(name = "comment_count")
+    val commentCount: Long,
     @Column(name = "created_at")
     @CreationTimestamp
     val createdAt: LocalDateTime = LocalDateTime.now(),

--- a/infra/rdb/src/main/resources/db/migration/V20241101146811__post_add_comment_count.sql
+++ b/infra/rdb/src/main/resources/db/migration/V20241101146811__post_add_comment_count.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `post`
+    ADD COLUMN `comment_count` BIGINT NOT NULL DEFAULT 0 AFTER `content`;

--- a/mvc-api/src/main/kotlin/com/jinuk/toy/mvcapi/view/post/response/PostDetailResponse.kt
+++ b/mvc-api/src/main/kotlin/com/jinuk/toy/mvcapi/view/post/response/PostDetailResponse.kt
@@ -13,7 +13,7 @@ data class PostDetailResponse(
     val content: String,
     val isViewerLike: Boolean,
     val likeCount: Int,
-    val commentCount: Int,
+    val commentCount: Long,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime,
 )

--- a/mvc-api/src/main/kotlin/com/jinuk/toy/mvcapi/view/post/response/PostSearchResponse.kt
+++ b/mvc-api/src/main/kotlin/com/jinuk/toy/mvcapi/view/post/response/PostSearchResponse.kt
@@ -9,7 +9,7 @@ class PostSearchResponse(
     val id: Long,
     val title: PostTitle,
     val userName: Username,
-    val commentCount: Int,
+    val commentCount: Long,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime,
 )


### PR DESCRIPTION
- Post 테이블에 commentCount 컬럼을 추가합니다.
- Post 테이블에 연관되어있는 Comment 개수를 세지않고, Post 테이블에 commentCount 을 통해서 댓글 개수를 처리합니다.
- 동시성 이슈가 있을 수 있어 분산락 적용